### PR TITLE
Simplify deployment configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,14 +4,9 @@
   "description": "NeuraLeap Website",
   "scripts": {
     "dev": "serve .",
-    "prebuild": "rm -rf dist",
-    "build": "mkdir -p dist && cp -r index.html assets css js components pages templates dist/ && cp vercel.json dist/ && cp package.json dist/",
-    "start": "serve dist"
+    "start": "serve ."
   },
   "dependencies": {
     "serve": "^14.2.1"
-  },
-  "devDependencies": {
-    "@vercel/static": "^2.0.0"
   }
 }


### PR DESCRIPTION
This PR simplifies the deployment configuration by:

1. Removing vercel.json - letting Vercel auto-detect the static site configuration
2. Simplifying package.json to just include basic serve commands
3. Removing unnecessary build scripts and dependencies

This makes the deployment process much simpler:
- No build process needed
- Files served directly from root directory
- Works the same locally and on Vercel

To deploy:
1. Leave all Vercel project settings at their defaults
2. No build command needed
3. No output directory needed (uses root)